### PR TITLE
Bump grafana/grafana from 9.5.3 to 10.1.1 in /grafana

### DIFF
--- a/grafana/Dockerfile
+++ b/grafana/Dockerfile
@@ -1,4 +1,4 @@
-FROM grafana/grafana:9.5.3
+FROM grafana/grafana:10.1.1
 
 ENV GF_ANALYTICS_REPORTING_ENABLED=FALSE \
     GF_AUTH_ANONYMOUS_ENABLED=false \


### PR DESCRIPTION
Bumps grafana/grafana from 9.5.3 to 10.1.1.

---
updated-dependencies:
- dependency-name: grafana/grafana dependency-type: direct:production update-type: version-update:semver-major ...
[View initial PR](https://github.com/adriankumpf/teslamate/pull/3329)