### PR TITLE
Upgrade esbuild devDependency as it clashes with a dependency version

### DIFF
--- a/assets/package.json
+++ b/assets/package.json
@@ -19,7 +19,7 @@
   },
   "devDependencies": {
     "bulma": "^0.9.4",
-    "esbuild": "^0.17.7",
+    "esbuild": "^0.19.4",
     "esbuild-sass-plugin": "^2.9.0",
     "sass": "^1.63.3"
   },


### PR DESCRIPTION
Asset builds failed for me as a peer dependency was referring to version `^0.19.4`. Upgrading to this fixed the issue.

[View initial PR](https://github.com/adriankumpf/teslamate/pull/3356)